### PR TITLE
[Feature] 게시물 상세 화면 기능 구현

### DIFF
--- a/app/src/main/java/desktop/hambug/presentation/community/PostDetailScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/community/PostDetailScreen.kt
@@ -15,10 +15,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,6 +32,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import desktop.hambug.R
+import desktop.hambug.presentation.community.component.DetailMyBottomSheet
+import desktop.hambug.presentation.community.component.DetailOtherBottomSheet
 import desktop.hambug.presentation.ui.icon.AppIcons
 import desktop.hambug.presentation.ui.icon.appicons.BackDetail
 import desktop.hambug.presentation.ui.icon.appicons.CommentDetail
@@ -33,8 +41,13 @@ import desktop.hambug.presentation.ui.icon.appicons.Dots
 import desktop.hambug.presentation.ui.icon.appicons.HeartBorder
 import desktop.hambug.presentation.ui.theme.HambugTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostDetailScreen() {
+
+    var showPostBottomSheet by remember { mutableStateOf(false) }
+    var showCommentBottomSheet by remember { mutableStateOf(false) }
+
     Surface (
         modifier = Modifier.fillMaxSize(),
         color = HambugTheme.colors.bgWhite
@@ -78,6 +91,7 @@ fun PostDetailScreen() {
                 }
 
                 Icon(
+                    modifier = Modifier.clickable { showPostBottomSheet = true },
                     imageVector = AppIcons.Dots,
                     contentDescription = null,
                     tint = Color.Unspecified
@@ -203,6 +217,7 @@ fun PostDetailScreen() {
                             color = HambugTheme.colors.textHeadline
                         )
                         Icon(
+                            modifier = Modifier.clickable { showCommentBottomSheet = true },
                             imageVector = AppIcons.Dots,
                             contentDescription = null,
                             tint = Color.Unspecified
@@ -224,6 +239,42 @@ fun PostDetailScreen() {
                     )
                 }
             }
+        }
+    }
+
+    // 게시물 바텀시트
+    if (showPostBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showPostBottomSheet = false },
+            dragHandle = null,
+            containerColor = HambugTheme.colors.bgWhite,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            // 자신의 게시물
+            DetailMyBottomSheet(
+                onEdit = {},
+                onDelete = {},
+                onCancel = { showPostBottomSheet = false }
+            )
+            // 타인의 게시물
+        }
+    }
+
+    // 댓글 바텀시트
+    if (showCommentBottomSheet) {
+        // 자신의 댓글
+
+        // 타인의 댓글
+        ModalBottomSheet(
+            onDismissRequest = { showCommentBottomSheet = false },
+            dragHandle = null,
+            containerColor = HambugTheme.colors.bgWhite,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            DetailOtherBottomSheet(
+                onReport = {},
+                onCancel = { showCommentBottomSheet = false }
+            )
         }
     }
 }

--- a/app/src/main/java/desktop/hambug/presentation/community/PostDetailScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/community/PostDetailScreen.kt
@@ -1,10 +1,8 @@
 package desktop.hambug.presentation.community
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -27,7 +26,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -58,137 +59,26 @@ fun PostDetailScreen() {
         ) {
             Spacer(modifier = Modifier.height(20.dp))
 
-            // 상단 닉네임 표시 영역
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .clickable {  }
-                            .padding(top = 10.dp, bottom = 10.dp, end = 16.dp),
-                        imageVector = AppIcons.BackDetail,
-                        contentDescription = null,
-                        tint = HambugTheme.colors.iconDefault
-                    )
-                    Image(
-                        modifier = Modifier.size(35.dp),
-                        painter = painterResource(id = R.drawable.logo_profile),
-                        contentDescription = null
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "닉네임",
-                        style = HambugTheme.typography.body02,
-                        color = HambugTheme.colors.textHeadline
-                    )
-                }
-
-                Icon(
-                    modifier = Modifier.clickable { showPostBottomSheet = true },
-                    imageVector = AppIcons.Dots,
-                    contentDescription = null,
-                    tint = Color.Unspecified
-                )
-            }
+            // 상단 프로필 영역
+            PostDetailProfileSection(
+                onClickBack = {},
+                onClickMore = { showPostBottomSheet = true }
+            )
 
             Spacer(modifier = Modifier.height(20.dp))
 
             // 제목 + 시간 + 내용 영역
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            ) {
-                Text(
-                    text = "맘스터치 싸이버거는 언제나 옳다! 겉바속촉 치킨 패티에 중독성 강한 소스가 대박!",
-                    style = HambugTheme.typography.title02,
-                    color = HambugTheme.colors.textHeadline
-                )
-
-                Spacer(modifier = Modifier.height(6.dp))
-
-                Text(
-                    text = "15분 전",
-                    style = HambugTheme.typography.label02,
-                    color = HambugTheme.colors.textDisabled
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = "오늘 점심으로 맘스터치 싸이버거를 먹었는데, 역시 기대를 저버리지 않았어요. 일단 패티가 정말 두툼하고 겉은 바삭, 속은 촉촉해서 식감이 일품이에요. 특히 매콤달콤한 소스가 중독성이 강해서 먹는 내내 행복했어요. 신선한 양상추와 부드러운 빵까지 완벽한 조합이었습니다",
-                    style = HambugTheme.typography.body02,
-                    color = HambugTheme.colors.textHeadline
-                )
-            }
+            PostDetailTextSection()
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            // 이미지 영역
-            Row(
-                modifier = Modifier.padding(start = 16.dp)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(272.dp)
-                        .background(color = HambugTheme.colors.bgDarker, shape = RoundedCornerShape(6.dp))
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Box(
-                    modifier = Modifier
-                        .size(272.dp)
-                        .background(color = HambugTheme.colors.bgDarker, shape = RoundedCornerShape(6.dp))
-                )
-            }
+            // 게시물 이미지 영역
+            PostDetailImageSection()
 
             Spacer(modifier = Modifier.height(32.dp))
 
             // 아이콘 영역
-            Row(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = AppIcons.HeartBorder,
-                        contentDescription = null,
-                        tint = HambugTheme.colors.primRed
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text = "11",
-                        style = HambugTheme.typography.body01,
-                        color = HambugTheme.colors.textDisabled
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(12.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = AppIcons.CommentDetail,
-                        contentDescription = null,
-                        tint = HambugTheme.colors.iconDisabled
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text = "6",
-                        style = HambugTheme.typography.body01,
-                        color = HambugTheme.colors.textDisabled
-                    )
-                }
-            }
+            PostDetailIconSection()
 
             Spacer(modifier = Modifier.height(36.dp))
 
@@ -274,6 +164,143 @@ fun PostDetailScreen() {
             DetailOtherBottomSheet(
                 onReport = {},
                 onCancel = { showCommentBottomSheet = false }
+            )
+        }
+    }
+}
+
+@Composable
+fun PostDetailProfileSection(
+    onClickBack: () -> Unit,
+    onClickMore: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier
+                    .clickable { onClickBack() }
+                    .padding(top = 10.dp, bottom = 10.dp, end = 16.dp),
+                imageVector = AppIcons.BackDetail,
+                contentDescription = null,
+                tint = HambugTheme.colors.iconDefault
+            )
+            Image(
+                modifier = Modifier.size(35.dp),
+                painter = painterResource(id = R.drawable.logo_profile),
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "닉네임",
+                style = HambugTheme.typography.body02,
+                color = HambugTheme.colors.textHeadline
+            )
+        }
+
+        Icon(
+            modifier = Modifier.clickable { onClickMore() },
+            imageVector = AppIcons.Dots,
+            contentDescription = null,
+            tint = Color.Unspecified
+        )
+    }
+}
+
+@Composable
+fun PostDetailTextSection() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        Text(
+            text = "맘스터치 싸이버거는 언제나 옳다! 겉바속촉 치킨 패티에 중독성 강한 소스가 대박!",
+            style = HambugTheme.typography.title02,
+            color = HambugTheme.colors.textHeadline
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = "15분 전",
+            style = HambugTheme.typography.label02,
+            color = HambugTheme.colors.textDisabled
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "오늘 점심으로 맘스터치 싸이버거를 먹었는데, 역시 기대를 저버리지 않았어요. 일단 패티가 정말 두툼하고 겉은 바삭, 속은 촉촉해서 식감이 일품이에요. 특히 매콤달콤한 소스가 중독성이 강해서 먹는 내내 행복했어요. 신선한 양상추와 부드러운 빵까지 완벽한 조합이었습니다",
+            style = HambugTheme.typography.body02,
+            color = HambugTheme.colors.textHeadline
+        )
+    }
+}
+
+@Composable
+fun PostDetailImageSection() {
+    LazyRow(
+        modifier = Modifier.padding(start = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        items(count = 5) {
+            Image(
+                modifier = Modifier
+                    .size(272.dp)
+                    .clip(RoundedCornerShape(6.dp)),
+                painter = painterResource(R.drawable.hambuger),
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}
+
+@Composable
+fun PostDetailIconSection() {
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = AppIcons.HeartBorder,
+                contentDescription = null,
+                tint = HambugTheme.colors.primRed
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "11",
+                style = HambugTheme.typography.body01,
+                color = HambugTheme.colors.textDisabled
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = AppIcons.CommentDetail,
+                contentDescription = null,
+                tint = HambugTheme.colors.iconDisabled
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "6",
+                style = HambugTheme.typography.body01,
+                color = HambugTheme.colors.textDisabled
             )
         }
     }

--- a/app/src/main/java/desktop/hambug/presentation/community/component/DetailMyBottomSheet.kt
+++ b/app/src/main/java/desktop/hambug/presentation/community/component/DetailMyBottomSheet.kt
@@ -1,0 +1,82 @@
+package desktop.hambug.presentation.community.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import desktop.hambug.presentation.ui.theme.HambugTheme
+
+@Composable
+fun DetailMyBottomSheet(
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .clickable { onEdit() }
+                .fillMaxWidth()
+                .background(color = HambugTheme.colors.bgNormal, RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "수정",
+                style = HambugTheme.typography.body02Prominent,
+                color = HambugTheme.colors.textBody
+            )
+        }
+
+        HorizontalDivider(thickness = 0.5.dp, color = HambugTheme.colors.bgDarker)
+
+
+        Box(
+            modifier = Modifier
+                .clickable { onDelete() }
+                .fillMaxWidth()
+                .background(color = HambugTheme.colors.bgNormal, RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "삭제",
+                style = HambugTheme.typography.body02Prominent,
+                color = HambugTheme.colors.primRed
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+
+        Box(
+            modifier = Modifier
+                .clickable { onCancel() }
+                .fillMaxWidth()
+                .background(color = HambugTheme.colors.bgNormal, RoundedCornerShape(12.dp))
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "취소",
+                style = HambugTheme.typography.body02Prominent,
+                color = HambugTheme.colors.textBody
+            )
+        }
+    }
+}

--- a/app/src/main/java/desktop/hambug/presentation/community/component/DetailOtherBottomSheet.kt
+++ b/app/src/main/java/desktop/hambug/presentation/community/component/DetailOtherBottomSheet.kt
@@ -1,0 +1,61 @@
+package desktop.hambug.presentation.community.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import desktop.hambug.presentation.ui.theme.HambugTheme
+
+@Composable
+fun DetailOtherBottomSheet(
+    onReport: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .clickable { onReport() }
+                .fillMaxWidth()
+                .background(color = HambugTheme.colors.bgNormal, RoundedCornerShape(12.dp))
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "신고",
+                style = HambugTheme.typography.body02Prominent,
+                color = HambugTheme.colors.primRed
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Box(
+            modifier = Modifier
+                .clickable { onCancel() }
+                .fillMaxWidth()
+                .background(color = HambugTheme.colors.bgNormal, RoundedCornerShape(12.dp))
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "취소",
+                style = HambugTheme.typography.body02Prominent,
+                color = HambugTheme.colors.textBody
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 어떤 작업을 했나요 ?
- 게시물 더보기 BottomSheet 구현
- 댓글 더보기 BottomSheet 구현
- LazyRow 이미지 목록 구현
## 작업 결과
| 자신의 게시물/댓글 | 타인의 게시물/댓글 | 이미지 목록 |
| :---: | :---: | :---: |
| <img src="https://github.com/user-attachments/assets/8a7c4a71-c72d-4a95-8cd2-58abff0502ec" width="300"> | <img src="https://github.com/user-attachments/assets/5b20b5da-fa03-48cd-9140-0a9e4e6efd30" width="300"> | <img src="https://github.com/user-attachments/assets/a5eeaf1b-e404-4b41-a9a3-ea43e862edcc" width="300"> |