### PR TITLE
[Feature] 알림 API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.config)
     // hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/main/java/desktop/hambug/MainActivity.kt
+++ b/app/src/main/java/desktop/hambug/MainActivity.kt
@@ -36,13 +36,19 @@ import desktop.hambug.presentation.login.LoginScreen
 import desktop.hambug.presentation.my.MyActivityScreen
 import desktop.hambug.presentation.my.MypageScreen
 import desktop.hambug.presentation.noti.NotificationScreen
+import desktop.hambug.presentation.ui.component.ForceUpdateDialog
 import desktop.hambug.presentation.ui.theme.HambugTheme
+import desktop.hambug.util.VersionManager
 import kotlinx.coroutines.flow.collectLatest
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val mainViewModel: MainViewModel by viewModels()
+
+    @Inject
+    lateinit var versionManager: VersionManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -55,6 +61,7 @@ class MainActivity : ComponentActivity() {
         // 알림 채널 생성 (Android 8.0 이상)
         createNotificationChannel()
 
+        // showNativeSplash가 true인 동안 계속 표시됨 (기본 스플래시)
         splashScreen.setKeepOnScreenCondition {
             mainViewModel.showNativeSplash.value
         }
@@ -63,15 +70,22 @@ class MainActivity : ComponentActivity() {
             HambugTheme {
                 val showNativeSplash by mainViewModel.showNativeSplash.collectAsStateWithLifecycle()
                 val startDestination by mainViewModel.startDestination.collectAsStateWithLifecycle()
+                val needForceUpdate by mainViewModel.needForceUpdate.collectAsStateWithLifecycle()
 
-                // 기본 스플래시가 끝난 후에 화면 그림
-                if (!showNativeSplash) {
-                    val destination = startDestination
+                if (needForceUpdate) {
+                    ForceUpdateDialog(
+                        onUpdateClick = { versionManager.openPlayStore(this) }
+                    )
+                } else {
+                    // 기본 스플래시가 끝난 후에 화면 그림
+                    if (!showNativeSplash) {
+                        val destination = startDestination
 
-                    if (destination == null) {
-                        SplashScreen()  // 커스텀 스플래시
-                    } else {
-                        HambugApp(startDestination = destination)
+                        if (destination == null) {
+                            SplashScreen()  // 커스텀 스플래시
+                        } else {
+                            HambugApp(startDestination = destination)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/desktop/hambug/MainActivity.kt
+++ b/app/src/main/java/desktop/hambug/MainActivity.kt
@@ -2,6 +2,7 @@ package desktop.hambug
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -39,6 +40,7 @@ import desktop.hambug.presentation.noti.NotificationScreen
 import desktop.hambug.presentation.ui.component.ForceUpdateDialog
 import desktop.hambug.presentation.ui.theme.HambugTheme
 import desktop.hambug.util.VersionManager
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import javax.inject.Inject
 
@@ -49,6 +51,8 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var versionManager: VersionManager
+
+    private val _fcmBoardId = MutableStateFlow<Int?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -61,12 +65,17 @@ class MainActivity : ComponentActivity() {
         // 알림 채널 생성 (Android 8.0 이상)
         createNotificationChannel()
 
+        // 앱 꺼진 상태에서 알림 클릭 시 여기서 검사
+        checkIntentForBoardId(intent)
+
         // showNativeSplash가 true인 동안 계속 표시됨 (기본 스플래시)
         splashScreen.setKeepOnScreenCondition {
             mainViewModel.showNativeSplash.value
         }
 
         setContent {
+            val fcmBoardId by _fcmBoardId.collectAsStateWithLifecycle()
+
             HambugTheme {
                 val showNativeSplash by mainViewModel.showNativeSplash.collectAsStateWithLifecycle()
                 val startDestination by mainViewModel.startDestination.collectAsStateWithLifecycle()
@@ -84,12 +93,22 @@ class MainActivity : ComponentActivity() {
                         if (destination == null) {
                             SplashScreen()  // 커스텀 스플래시
                         } else {
-                            HambugApp(startDestination = destination)
+                            HambugApp(
+                                startDestination = destination,
+                                fcmBoardId = fcmBoardId,
+                                onConsumeFcmId = { _fcmBoardId.value = null }
+                            )
                         }
                     }
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // 앱 켜진 상태에서 알림 클릭 시 여기서 검사
+        checkIntentForBoardId(intent)
     }
 
     private fun createNotificationChannel() {
@@ -104,12 +123,25 @@ class MainActivity : ComponentActivity() {
         val notificationManager = getSystemService(NotificationManager::class.java)
         notificationManager.createNotificationChannel(channel)
     }
+
+    private fun checkIntentForBoardId(intent: Intent?) {
+        if (intent?.hasExtra("boardId") == true) {
+            val boardId = intent.getIntExtra("boardId", -1)
+            if (boardId != -1) {
+                _fcmBoardId.value = boardId
+                // 중복 처리 방지
+                intent.removeExtra("boardId")
+            }
+        }
+    }
 }
 
 @Composable
 fun HambugApp(
     startDestination: String,
-    mainViewModel: MainViewModel = hiltViewModel()
+    mainViewModel: MainViewModel = hiltViewModel(),
+    fcmBoardId: Int? = null,
+    onConsumeFcmId: () -> Unit = {}
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -123,6 +155,14 @@ fun HambugApp(
                 popUpTo(navController.graph.id) { inclusive = true }
                 launchSingleTop = true
             }
+        }
+    }
+
+    // fcmBoardId 값이 들어오면 해당 화면으로 이동
+    LaunchedEffect(fcmBoardId) {
+        if (fcmBoardId != null) {
+            navController.navigate("community_detail/$fcmBoardId")
+            onConsumeFcmId()
         }
     }
 

--- a/app/src/main/java/desktop/hambug/MainViewModel.kt
+++ b/app/src/main/java/desktop/hambug/MainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import desktop.hambug.data.local.HambugTokenManager
+import desktop.hambug.util.VersionManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val tokenManager: HambugTokenManager
+    private val tokenManager: HambugTokenManager,
+    private val versionManager: VersionManager
 ) : ViewModel() {
 
     private val _showNativeSplash = MutableStateFlow(true)
@@ -29,13 +31,32 @@ class MainViewModel @Inject constructor(
     private val _logoutEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val logoutEvent: SharedFlow<Unit> = _logoutEvent.asSharedFlow()
 
+    private val _needForceUpdate = MutableStateFlow(false)
+    val needForceUpdate: StateFlow<Boolean> = _needForceUpdate.asStateFlow()
+
     companion object {
         private const val CUSTOM_SPLASH_DURATION = 1500L
     }
 
     init {
-        checkLoginStatus()
+        checkAppVersion()
         observeLogoutEvent()
+    }
+
+    private fun checkAppVersion() {
+        viewModelScope.launch {
+            versionManager.getVersionInfo()
+
+            if (versionManager.isForceUpdateRequired()) {
+                _needForceUpdate.value = true
+                // Native Splash가 Dialog를 가리지 않도록 설정
+                _showNativeSplash.value = false
+                return@launch
+            }
+
+            // 업데이트 필요 없으면 기존 로직 진행
+            checkLoginStatus()
+        }
     }
 
     // 앱 시작 시 토큰 유무 확인

--- a/app/src/main/java/desktop/hambug/data/api/HambugApi.kt
+++ b/app/src/main/java/desktop/hambug/data/api/HambugApi.kt
@@ -23,6 +23,7 @@ import desktop.hambug.data.dto.community.MyCommentsResponse
 import desktop.hambug.data.dto.fcm.FcmTokenRequest
 import desktop.hambug.data.dto.fcm.FcmTokenResponse
 import desktop.hambug.data.dto.home.HomeBoardResponse
+import desktop.hambug.data.dto.fcm.NotisResponse
 import desktop.hambug.data.dto.report.ReportRequest
 import desktop.hambug.data.dto.report.ReportResponse
 import okhttp3.MultipartBody
@@ -166,4 +167,8 @@ interface HambugApi {
     suspend fun updateFcmToken(
         @Body request: FcmTokenRequest
     ): FcmTokenResponse
+
+    // 알림 목록 조회
+    @GET("notifications")
+    suspend fun getNotis(): NotisResponse
 }

--- a/app/src/main/java/desktop/hambug/data/dto/fcm/NotisResponse.kt
+++ b/app/src/main/java/desktop/hambug/data/dto/fcm/NotisResponse.kt
@@ -1,0 +1,42 @@
+package desktop.hambug.data.dto.fcm
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotisResponse(
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("data")
+    val data: NotisData,
+    @SerialName("message")
+    val message: String
+)
+
+@Serializable
+data class NotisData(
+    @SerialName("content")
+    val content: List<NotiItem>,
+    @SerialName("lastId")
+    val lastId: Int,
+    @SerialName("hasNext")
+    val hasNext: Boolean
+)
+
+@Serializable
+data class NotiItem(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("title")
+    val title: String,
+    @SerialName("content")
+    val content: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("targetId")
+    val targetId: Int,
+    @SerialName("isRead")
+    val isRead: Boolean,
+    @SerialName("createdAt")
+    val createdAt: String
+)

--- a/app/src/main/java/desktop/hambug/data/dto/fcm/NotisResponse.kt
+++ b/app/src/main/java/desktop/hambug/data/dto/fcm/NotisResponse.kt
@@ -16,27 +16,29 @@ data class NotisResponse(
 @Serializable
 data class NotisData(
     @SerialName("content")
-    val content: List<NotiItem>,
+    val content: List<NotiItem> = emptyList(),
     @SerialName("lastId")
-    val lastId: Int,
+    val lastId: Int? = null,
     @SerialName("hasNext")
-    val hasNext: Boolean
+    val hasNext: Boolean = false
 )
 
 @Serializable
 data class NotiItem(
     @SerialName("id")
-    val id: Int,
+    val id: Int? = null,
     @SerialName("title")
-    val title: String,
+    val title: String? = null,
     @SerialName("content")
-    val content: String,
+    val content: String? = null,
     @SerialName("type")
-    val type: String,
+    val type: String? = null,
     @SerialName("targetId")
-    val targetId: Int,
+    val targetId: Int? = null,
+    @SerialName("thumbnailUrl")
+    val thumbnailUrl: String? = null,
     @SerialName("isRead")
-    val isRead: Boolean,
+    val isRead: Boolean? = null,
     @SerialName("createdAt")
-    val createdAt: String
+    val createdAt: String? = null
 )

--- a/app/src/main/java/desktop/hambug/data/mapper/ResponseToEntity.kt
+++ b/app/src/main/java/desktop/hambug/data/mapper/ResponseToEntity.kt
@@ -125,10 +125,12 @@ fun MyCommentItem.toEntity(): MyComment {
 
 fun NotiItem.toEntity(): Noti {
     return Noti(
-        notiId = this.id,
-        content = this.content,
-        type = this.type,
-        targetId = this.targetId,
-        createdAt = this.createdAt
+        notiId = this.id ?: -1,
+        title = this.title ?: "",
+        content = this.content ?: "",
+        type = this.type ?: "",
+        targetId = this.targetId ?: -1,
+        thumbnailUrl = this.thumbnailUrl ?: "",
+        createdAt = this.createdAt ?: ""
     )
 }

--- a/app/src/main/java/desktop/hambug/data/mapper/ResponseToEntity.kt
+++ b/app/src/main/java/desktop/hambug/data/mapper/ResponseToEntity.kt
@@ -8,6 +8,7 @@ import desktop.hambug.data.dto.community.BoardsData
 import desktop.hambug.data.dto.community.CommentItem
 import desktop.hambug.data.dto.community.MyBoardItem
 import desktop.hambug.data.dto.community.MyCommentItem
+import desktop.hambug.data.dto.fcm.NotiItem
 import desktop.hambug.data.dto.home.HomeBoardData
 import desktop.hambug.domain.model.Board
 import desktop.hambug.domain.model.BoardDetail
@@ -17,6 +18,7 @@ import desktop.hambug.domain.model.HomeBoard
 import desktop.hambug.domain.model.HomeBurger
 import desktop.hambug.domain.model.MyBoard
 import desktop.hambug.domain.model.MyComment
+import desktop.hambug.domain.model.Noti
 import desktop.hambug.domain.model.UserInfo
 
 fun HomeBurgerData.toEntity(): HomeBurger {
@@ -117,6 +119,16 @@ fun MyCommentItem.toEntity(): MyComment {
         boardTitle = this.title,
         commentId = this.commentId,
         commentContent = this.content,
+        createdAt = this.createdAt
+    )
+}
+
+fun NotiItem.toEntity(): Noti {
+    return Noti(
+        notiId = this.id,
+        content = this.content,
+        type = this.type,
+        targetId = this.targetId,
         createdAt = this.createdAt
     )
 }

--- a/app/src/main/java/desktop/hambug/data/repository/FcmRepositoryImpl.kt
+++ b/app/src/main/java/desktop/hambug/data/repository/FcmRepositoryImpl.kt
@@ -2,6 +2,8 @@ package desktop.hambug.data.repository
 
 import desktop.hambug.data.api.HambugApi
 import desktop.hambug.data.dto.fcm.FcmTokenRequest
+import desktop.hambug.data.mapper.toEntity
+import desktop.hambug.domain.model.Noti
 import desktop.hambug.domain.repository.FcmRepository
 import javax.inject.Inject
 
@@ -16,5 +18,15 @@ class FcmRepositoryImpl @Inject constructor(
         if (!response.success) {
             throw Exception(response.message)
         }
+    }
+
+    override suspend fun getNotis(): List<Noti> {
+        val response = hambugApi.getNotis()
+
+        if (!response.success) {
+            throw Exception(response.message)
+        }
+
+        return response.data.content.map { it.toEntity() }
     }
 }

--- a/app/src/main/java/desktop/hambug/domain/model/Noti.kt
+++ b/app/src/main/java/desktop/hambug/domain/model/Noti.kt
@@ -2,8 +2,10 @@ package desktop.hambug.domain.model
 
 data class Noti(
     val notiId: Int,
+    val title: String,
     val content: String,
     val type: String,
     val targetId: Int,
+    val thumbnailUrl: String,
     val createdAt: String
 )

--- a/app/src/main/java/desktop/hambug/domain/model/Noti.kt
+++ b/app/src/main/java/desktop/hambug/domain/model/Noti.kt
@@ -1,0 +1,9 @@
+package desktop.hambug.domain.model
+
+data class Noti(
+    val notiId: Int,
+    val content: String,
+    val type: String,
+    val targetId: Int,
+    val createdAt: String
+)

--- a/app/src/main/java/desktop/hambug/domain/repository/FcmRepository.kt
+++ b/app/src/main/java/desktop/hambug/domain/repository/FcmRepository.kt
@@ -1,5 +1,8 @@
 package desktop.hambug.domain.repository
 
+import desktop.hambug.domain.model.Noti
+
 interface FcmRepository {
     suspend fun updateFcmToken(token: String)
+    suspend fun getNotis(): List<Noti>
 }

--- a/app/src/main/java/desktop/hambug/domain/usecase/fcm/GetNotisUseCase.kt
+++ b/app/src/main/java/desktop/hambug/domain/usecase/fcm/GetNotisUseCase.kt
@@ -1,0 +1,15 @@
+package desktop.hambug.domain.usecase.fcm
+
+import desktop.hambug.domain.model.Noti
+import desktop.hambug.domain.repository.FcmRepository
+import javax.inject.Inject
+
+class GetNotisUseCase @Inject constructor(
+    private val repository: FcmRepository
+){
+    suspend operator fun invoke(): Result<List<Noti>> {
+        return runCatching {
+            repository.getNotis()
+        }
+    }
+}

--- a/app/src/main/java/desktop/hambug/notification/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/desktop/hambug/notification/MyFirebaseMessagingService.kt
@@ -31,7 +31,9 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         Timber.d("fcm 메시지 수신 - data: ${message.data}")
-        Timber.d("fcm 메시지 수신 - notification: ${message.notification}")
+
+        val data = message.data
+        val boardId = data["boardId"]
 
         val title = message.notification?.title
             ?: message.data["title"]
@@ -41,7 +43,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             ?: "새로운 알림이 도착했습니다"
 
         // 시스템 알림 표시
-        showNotification(title, body)
+        showNotification(title, body, boardId)
     }
 
     override fun onNewToken(token: String) {
@@ -65,12 +67,17 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun showNotification(title: String, body: String) {
+    private fun showNotification(title: String, body: String, boardId: String?) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         // 알림 클릭 시 앱 실행
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+
+            // Intent에 boardId 담기
+            boardId?.toIntOrNull()?.let {
+                putExtra("boardId", it)
+            }
         }
 
         val pendingIntent = PendingIntent.getActivity(
@@ -91,7 +98,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             .setContentIntent(pendingIntent)
             .build()
 
-        // 각 알림에 고유한 ID 부여
+        // 알림을 화면에 띄움
         notificationManager.notify(System.currentTimeMillis().toInt(), notification)
     }
 }

--- a/app/src/main/java/desktop/hambug/notification/NotificationPermissionHelper.kt
+++ b/app/src/main/java/desktop/hambug/notification/NotificationPermissionHelper.kt
@@ -1,4 +1,4 @@
-package desktop.hambug.util
+package desktop.hambug.notification
 
 import android.Manifest
 import android.content.Context

--- a/app/src/main/java/desktop/hambug/presentation/component/EmptyStateView.kt
+++ b/app/src/main/java/desktop/hambug/presentation/component/EmptyStateView.kt
@@ -1,0 +1,43 @@
+package desktop.hambug.presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import desktop.hambug.R
+import desktop.hambug.presentation.ui.theme.HambugTheme
+
+@Composable
+fun EmptyStateView(
+    modifier: Modifier = Modifier,
+    message: String
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Image(
+            modifier = Modifier.size(96.dp),
+            painter = painterResource(id = R.drawable.logo_login),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(HambugTheme.colors.borderDisabled)
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = message,
+            style = HambugTheme.typography.body02,
+            color = HambugTheme.colors.borderDefault
+        )
+    }
+}

--- a/app/src/main/java/desktop/hambug/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/login/LoginScreen.kt
@@ -43,7 +43,7 @@ import desktop.hambug.presentation.ui.icon.appicons.Kakao
 import desktop.hambug.presentation.ui.theme.Gray1000
 import desktop.hambug.presentation.ui.theme.HambugTheme
 import desktop.hambug.presentation.ui.theme.KakaoYellow
-import desktop.hambug.util.NotificationPermissionHelper
+import desktop.hambug.notification.NotificationPermissionHelper
 import timber.log.Timber
 
 @Composable

--- a/app/src/main/java/desktop/hambug/presentation/my/MyActivityScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/my/MyActivityScreen.kt
@@ -46,6 +46,7 @@ import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import desktop.hambug.domain.model.MyBoard
 import desktop.hambug.domain.model.MyComment
+import desktop.hambug.presentation.component.EmptyStateView
 import desktop.hambug.presentation.ui.component.HambugLoadingIndicator
 import desktop.hambug.presentation.ui.icon.AppIcons
 import desktop.hambug.presentation.ui.icon.appicons.BackDetail
@@ -183,22 +184,28 @@ fun TwoTabSection(
                         }
                         is MyActivityUiState.Error -> {}
                         is MyActivityUiState.Success -> {
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .background(color = HambugTheme.colors.bgWhite, shape = RoundedCornerShape(6.dp)),
-                                state = rememberLazyListState(),
-                                contentPadding = PaddingValues(20.dp),
-                                verticalArrangement = Arrangement.spacedBy(24.dp)
-                            ) {
-                                items(
-                                    items = uiState.boards,
-                                    key = { it.id }
-                                ) { board ->
-                                    MyBoardItem(
-                                        board = board,
-                                        onClick = { onClick(board.id) }
-                                    )
+                            val boards = uiState.boards
+
+                            if (boards.isEmpty()) {
+                                EmptyStateView(message = "작성한 게시물이 없어요.")
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(color = HambugTheme.colors.bgWhite, shape = RoundedCornerShape(6.dp)),
+                                    state = rememberLazyListState(),
+                                    contentPadding = PaddingValues(20.dp),
+                                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                                ) {
+                                    items(
+                                        items = uiState.boards,
+                                        key = { it.id }
+                                    ) { board ->
+                                        MyBoardItem(
+                                            board = board,
+                                            onClick = { onClick(board.id) }
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -216,22 +223,28 @@ fun TwoTabSection(
                         }
                         is MyCommentUiState.Error -> {}
                         is MyCommentUiState.Success -> {
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .background(color = HambugTheme.colors.bgWhite, shape = RoundedCornerShape(6.dp)),
-                                state = rememberLazyListState(),
-                                contentPadding = PaddingValues(20.dp),
-                                verticalArrangement = Arrangement.spacedBy(24.dp)
-                            ) {
-                                items(
-                                    items = commentsState.comments,
-                                    key = { it.commentId }
-                                ) { comment ->
-                                    MyCommentItem(
-                                        comment = comment,
-                                        onClick = { onClick(comment.boardId) }
-                                    )
+                            val comments = commentsState.comments
+
+                            if (comments.isEmpty()) {
+                                EmptyStateView(message = "작성한 댓글이 없어요.")
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(color = HambugTheme.colors.bgWhite, shape = RoundedCornerShape(6.dp)),
+                                    state = rememberLazyListState(),
+                                    contentPadding = PaddingValues(20.dp),
+                                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                                ) {
+                                    items(
+                                        items = commentsState.comments,
+                                        key = { it.commentId }
+                                    ) { comment ->
+                                        MyCommentItem(
+                                            comment = comment,
+                                            onClick = { onClick(comment.boardId) }
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotiUiState.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotiUiState.kt
@@ -1,0 +1,9 @@
+package desktop.hambug.presentation.noti
+
+import desktop.hambug.domain.model.Noti
+
+sealed class NotiUiState {
+    data object Loading: NotiUiState()
+    data class Success(val notis: List<Noti>): NotiUiState()
+    data class Error(val message: String): NotiUiState()
+}

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import desktop.hambug.R
 import desktop.hambug.presentation.noti.component.NotiItem
@@ -32,7 +33,10 @@ import desktop.hambug.presentation.ui.theme.HambugTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationScreen(navController: NavHostController) {
+fun NotificationScreen(
+    navController: NavHostController,
+    notificationViewModel: NotificationViewModel = hiltViewModel()
+) {
     Scaffold(
         containerColor = Color.White,
         topBar = {

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
@@ -101,10 +101,11 @@ fun NotificationScreen(
                             key = { it.notiId }
                         ) { noti ->
                             NotiItem(
-                                content = noti.content,
-                                createdAt = noti.createdAt,
+                                noti = noti,
                                 onClick = {
-                                    navController.navigate("community_detail/${noti.targetId}")
+                                    if (noti.targetId != -1) {
+                                        navController.navigate("community_detail/${noti.targetId}")
+                                    }
                                 }
                             )
                             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotificationScreen.kt
@@ -1,32 +1,35 @@
 package desktop.hambug.presentation.noti
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import desktop.hambug.R
+import desktop.hambug.presentation.component.EmptyStateView
 import desktop.hambug.presentation.noti.component.NotiItem
+import desktop.hambug.presentation.ui.component.HambugLoadingIndicator
 import desktop.hambug.presentation.ui.icon.AppIcons
 import desktop.hambug.presentation.ui.icon.appicons.Back
 import desktop.hambug.presentation.ui.theme.HambugTheme
@@ -37,6 +40,8 @@ fun NotificationScreen(
     navController: NavHostController,
     notificationViewModel: NotificationViewModel = hiltViewModel()
 ) {
+    val uiState by notificationViewModel.uiState.collectAsStateWithLifecycle()
+
     Scaffold(
         containerColor = Color.White,
         topBar = {
@@ -64,73 +69,51 @@ fun NotificationScreen(
             )
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Image(
-                modifier = Modifier.size(96.dp),
-                painter = painterResource(id = R.drawable.logo_login),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(HambugTheme.colors.borderDisabled)
-            )
-            Spacer(Modifier.height(16.dp))
-            Text(
-                text = "아직 받은 알림이 없어요.",
-                style = HambugTheme.typography.body02,
-                color = HambugTheme.colors.borderDefault
-            )
+
+        when (uiState) {
+            is NotiUiState.Loading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    HambugLoadingIndicator()
+                }
+            }
+            is NotiUiState.Error -> {}
+            is NotiUiState.Success -> {
+                val notis = (uiState as NotiUiState.Success).notis
+
+                if (notis.isEmpty()) {
+                    EmptyStateView(
+                        modifier = Modifier.padding(paddingValues),
+                        message = "아직 받은 알림이 없어요."
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                        contentPadding = PaddingValues(vertical = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        items(
+                            items = notis,
+                            key = { it.notiId }
+                        ) { noti ->
+                            NotiItem(
+                                content = noti.content,
+                                createdAt = noti.createdAt,
+                                onClick = {
+                                    navController.navigate("community_detail/${noti.targetId}")
+                                }
+                            )
+                            Spacer(Modifier.height(16.dp))
+                            HorizontalDivider(thickness = 1.dp, color = HambugTheme.colors.bgDarker)
+                        }
+                    }
+                }
+            }
         }
-
-        // 알림 아이템 1개 이상인 경우
-//        Column(
-//            modifier = Modifier
-//                .padding(paddingValues)
-//                .padding(horizontal = 20.dp)
-//        ) {
-//            for (idx in 0 until 3) {
-//                NotiItem(
-//                    content = "라떼님이 내 게시물을 좋아합니다.",
-//                    onClick = {},
-//                    modifier = Modifier.padding(vertical = 14.dp)
-//                )
-//                NotiItem(
-//                    content = "사랑에빠진햄버거피자님이 내 게시물을 좋아합니다.",
-//                    onClick = {},
-//                    modifier = Modifier.padding(vertical = 14.dp)
-//                )
-//                NotiItem(
-//                    content = "사랑에빠진햄버거피자님이 내 게시물에 댓글을 달았습니다.",
-//                    onClick = {},
-//                    modifier = Modifier.padding(vertical = 14.dp)
-//                )
-//            }
-//        }
-
-        // 알림 아이템 없는 경우
-//        Column(
-//            modifier = Modifier
-//                .padding(paddingValues)
-//                .fillMaxSize(),
-//            verticalArrangement = Arrangement.Center,
-//            horizontalAlignment = Alignment.CenterHorizontally
-//        ) {
-//            Image(
-//                modifier = Modifier.size(96.dp),
-//                painter = painterResource(id = R.drawable.logo_login),
-//                contentDescription = null,
-//                colorFilter = ColorFilter.tint(HambugTheme.colors.borderDisabled)
-//            )
-//            Spacer(Modifier.height(16.dp))
-//            Text(
-//                text = "아직 받은 알림이 없어요.",
-//                style = HambugTheme.typography.body02Prominent,
-//                color = HambugTheme.colors.borderDefault
-//            )
-//        }
     }
 }
 

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotificationViewModel.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotificationViewModel.kt
@@ -1,0 +1,31 @@
+package desktop.hambug.presentation.noti
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import desktop.hambug.domain.usecase.fcm.GetNotisUseCase
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor(
+    private val getNotisUseCase: GetNotisUseCase
+) : ViewModel() {
+
+    init {
+        loadNotis()
+    }
+
+    private fun loadNotis() {
+        viewModelScope.launch {
+            getNotisUseCase()
+                .onSuccess { notis ->
+                    Timber.d("notis: $notis")
+                }
+                .onFailure { exception ->
+                    Timber.e(exception, "알림 목록 조회 실패")
+                }
+        }
+    }
+}

--- a/app/src/main/java/desktop/hambug/presentation/noti/NotificationViewModel.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/NotificationViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import desktop.hambug.domain.usecase.fcm.GetNotisUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -13,6 +16,9 @@ class NotificationViewModel @Inject constructor(
     private val getNotisUseCase: GetNotisUseCase
 ) : ViewModel() {
 
+    private val _uiState = MutableStateFlow<NotiUiState>(NotiUiState.Loading)
+    val uiState: StateFlow<NotiUiState> = _uiState.asStateFlow()
+
     init {
         loadNotis()
     }
@@ -21,7 +27,11 @@ class NotificationViewModel @Inject constructor(
         viewModelScope.launch {
             getNotisUseCase()
                 .onSuccess { notis ->
-                    Timber.d("notis: $notis")
+                    // content 내부의 ": " -> ":\n" 으로 변환
+                    val newNotis = notis.map { noti ->
+                        noti.copy(content = noti.content.replace(": ", ":\n"))
+                    }
+                    _uiState.value = NotiUiState.Success(newNotis)
                 }
                 .onFailure { exception ->
                     Timber.e(exception, "알림 목록 조회 실패")

--- a/app/src/main/java/desktop/hambug/presentation/noti/component/NotiItem.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/component/NotiItem.kt
@@ -1,10 +1,7 @@
 package desktop.hambug.presentation.noti.component
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,17 +14,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import desktop.hambug.R
+import coil3.compose.AsyncImage
+import desktop.hambug.domain.model.Noti
 import desktop.hambug.presentation.ui.theme.HambugTheme
+import desktop.hambug.presentation.util.getDisplayMessage
 import desktop.hambug.presentation.util.toTimeAgoString
 
 @Composable
 fun NotiItem(
-    content: String,
-    createdAt: String,
+    noti: Noti,
     onClick: () -> Unit
 ) {
     Row(
@@ -42,31 +40,43 @@ fun NotiItem(
             modifier = Modifier.weight(1f)
         ) {
             Text(
-                text = createdAt.toTimeAgoString(),
+                text = noti.createdAt.toTimeAgoString(),
                 style = HambugTheme.typography.label02,
                 color = HambugTheme.colors.textDisabled
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = content,
+                text = noti.getDisplayMessage(),
                 style = HambugTheme.typography.body02Prominent,
                 color = HambugTheme.colors.textHeadline
             )
         }
 
-        Box(
-            modifier = Modifier
-                .padding(start = 10.dp)
-                .size(44.dp)
-                .background(color = HambugTheme.colors.bgDarker, shape = RoundedCornerShape(5.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            Image(
-                modifier = Modifier.size(28.dp),
-                painter = painterResource(id = R.drawable.logo_login),
+        if (noti.thumbnailUrl.isNotEmpty()) {
+            AsyncImage(
+                modifier = Modifier
+                    .padding(start = 10.dp)
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(5.dp)),
+                model = noti.thumbnailUrl,
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(HambugTheme.colors.borderDefault)
+                contentScale = ContentScale.Crop
             )
         }
+
+//        Box(
+//            modifier = Modifier
+//                .padding(start = 10.dp)
+//                .size(44.dp)
+//                .background(color = HambugTheme.colors.bgDarker, shape = RoundedCornerShape(5.dp)),
+//            contentAlignment = Alignment.Center
+//        ) {
+//            Image(
+//                modifier = Modifier.size(28.dp),
+//                painter = painterResource(id = R.drawable.logo_login),
+//                contentDescription = null,
+//                colorFilter = ColorFilter.tint(HambugTheme.colors.borderDefault)
+//            )
+//        }
     }
 }

--- a/app/src/main/java/desktop/hambug/presentation/noti/component/NotiItem.kt
+++ b/app/src/main/java/desktop/hambug/presentation/noti/component/NotiItem.kt
@@ -1,52 +1,48 @@
 package desktop.hambug.presentation.noti.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import desktop.hambug.R
 import desktop.hambug.presentation.ui.theme.HambugTheme
+import desktop.hambug.presentation.util.toTimeAgoString
 
 @Composable
 fun NotiItem(
     content: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    createdAt: String,
+    onClick: () -> Unit
 ) {
     Row(
-        modifier = modifier
-            .clickable(onClick = onClick)
-            .fillMaxWidth(),
+        modifier = Modifier
+            .clickable { onClick() }
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            painter = painterResource(R.drawable.hambuger),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(44.dp)
-                .clip(RoundedCornerShape(5.dp))
-        )
-
-        Spacer(Modifier.width(10.dp))
-
-        Column {
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
             Text(
-                text = "1시간 전",
+                text = createdAt.toTimeAgoString(),
                 style = HambugTheme.typography.label02,
                 color = HambugTheme.colors.textDisabled
             )
@@ -55,6 +51,21 @@ fun NotiItem(
                 text = content,
                 style = HambugTheme.typography.body02Prominent,
                 color = HambugTheme.colors.textHeadline
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .padding(start = 10.dp)
+                .size(44.dp)
+                .background(color = HambugTheme.colors.bgDarker, shape = RoundedCornerShape(5.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                modifier = Modifier.size(28.dp),
+                painter = painterResource(id = R.drawable.logo_login),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(HambugTheme.colors.borderDefault)
             )
         }
     }

--- a/app/src/main/java/desktop/hambug/presentation/ui/component/ForceUpdateDialog.kt
+++ b/app/src/main/java/desktop/hambug/presentation/ui/component/ForceUpdateDialog.kt
@@ -1,0 +1,92 @@
+package desktop.hambug.presentation.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import desktop.hambug.presentation.ui.theme.HambugTheme
+
+@Composable
+fun ForceUpdateDialog(
+    onUpdateClick: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = { },
+        properties = DialogProperties(
+            dismissOnBackPress = false,    // 뒤로가기 막기
+            dismissOnClickOutside = false  // dialog 외부 클릭 막기
+        )
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            color = HambugTheme.colors.bgWhite
+        ) {
+            Box(
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, top = 36.dp, bottom = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "업데이트 안내",
+                        style = HambugTheme.typography.title02,
+                        color = HambugTheme.colors.textHeadline
+                    )
+
+                    Spacer(Modifier.height(16.dp))
+
+                    Text(
+                        text = "해당 버전은 더 이상 지원하지 않습니다.",
+                        style = HambugTheme.typography.body03,
+                        color = HambugTheme.colors.textDisabled,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    Box(
+                        modifier = Modifier
+                            .clickable { onUpdateClick() }
+                            .fillMaxWidth()
+                            .background(color = HambugTheme.colors.primRed, shape = RoundedCornerShape(12.dp))
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "업데이트 하러 가기",
+                            style = HambugTheme.typography.body02Prominent,
+                            color = HambugTheme.colors.bgWhite
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun UpdataCheckDialogPreview() {
+    HambugTheme {
+//        ForceUpdateDialog()
+    }
+}

--- a/app/src/main/java/desktop/hambug/presentation/util/StringExt.kt
+++ b/app/src/main/java/desktop/hambug/presentation/util/StringExt.kt
@@ -1,5 +1,7 @@
 package desktop.hambug.presentation.util
 
+import desktop.hambug.domain.model.Noti
+
 fun String.toKoreanCategory(): String {
     return when (this) {
         "FREE_TALK" -> "자유잡담"
@@ -8,5 +10,14 @@ fun String.toKoreanCategory(): String {
         "REVIEW" -> "햄버거리뷰"
         "RECOMMENDATION" -> "맛집추천"
         else -> this
+    }
+}
+
+fun Noti.getDisplayMessage(): String {
+    if (type != "LIKE_NOTIFICATION") return content
+
+    return when {
+        title.contains("외") -> "${title}이 $content"
+        else -> "${title}님이 $content"
     }
 }

--- a/app/src/main/java/desktop/hambug/util/VersionManager.kt
+++ b/app/src/main/java/desktop/hambug/util/VersionManager.kt
@@ -1,0 +1,87 @@
+package desktop.hambug.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.pm.PackageManager
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+import androidx.core.net.toUri
+import timber.log.Timber
+
+@Singleton
+class VersionManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val remoteConfig: FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
+
+    init {
+        // Remote Config 설정
+        val configSetting = remoteConfigSettings {
+            minimumFetchIntervalInSeconds = 3600  // 1시간
+        }
+        remoteConfig.setConfigSettingsAsync(configSetting)
+
+        // 기본값 설정
+        remoteConfig.setDefaultsAsync(
+            mapOf(
+                "android_min_version_code" to 1L
+            )
+        )
+    }
+
+    /**
+     * Remote Config에서 버전 정보 가져오기
+     */
+    suspend fun getVersionInfo(): Result<Unit> {
+        return try {
+            remoteConfig.fetchAndActivate().await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * 현재 앱 버전 코드 가져오기
+     */
+    private fun getCurrentVersionCode(): Long {
+        return try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            packageInfo.longVersionCode
+        } catch (e: PackageManager.NameNotFoundException) {
+            1L
+        }
+    }
+
+    /**
+     * 강제 업데이트가 필요한지 확인
+     */
+    fun isForceUpdateRequired(): Boolean {
+        val currentVersionCode = getCurrentVersionCode()
+        val minVersionCode = remoteConfig.getLong("android_min_version_code")
+        return currentVersionCode < minVersionCode
+    }
+
+    /**
+     * 구글 플레이 스토어로 이동
+     */
+    fun openPlayStore(context: Context) {
+        val packageName = context.packageName
+        try {
+            // 스토어 앱으로 이동 시도
+            val intent = android.content.Intent(
+                android.content.Intent.ACTION_VIEW,
+                "market://details?id=$packageName".toUri()
+            )
+            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            // 스토어 앱이 없는 경우
+            Timber.e(e, "Play 스토어 앱을 찾을 수 없습니다")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
+firebase-config = { module = "com.google.firebase:firebase-config" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCopmose" }


### PR DESCRIPTION
## 어떤 작업을 했나요 ?
- 알림 목록 조회 API 연동
- 알림 목록 데이터 표시 및 게시물 상세 이동
- 알림 목록 내 이미지 필드 추가
- 푸시알림 클릭 시 게시물 상세로 이동
- 활동내역 데이터 없는 경우 안내문구 추가
- Remote Config 기반 강제 업데이트 구현

## 작업 결과
| 알림 목록 | 업데이트 안내 |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/dab32062-7aa6-4472-b08c-3f70d879fac8" width="300"> | <img src="https://github.com/user-attachments/assets/2a762027-acb9-47bf-baed-e83297fb4a70" width="300"> |





